### PR TITLE
US-9910 Disabled building build tools for bimg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ HunterGate(
 
 project(bimg VERSION 1.0.0)
 
-option(BIMG_BUILD_TOOLS "Build bimg tools." ON)
+option(BIMG_BUILD_TOOLS "Build bimg tools." OFF)
 
 ################################################################################
 # 3rdparty libs


### PR DESCRIPTION
texturec would not build on hunter when building BGFX for tvOS.
Disabled creating executable build tools for bimg, not necessary.